### PR TITLE
Turbo - ActionCable integration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem "sqlite3"
 gem "sprockets-rails"
 gem 'puma', '~> 5.6', '>= 5.6.4'
 gem 'importmap-rails', '~> 1.1', '>= 1.1.2'
+gem 'redis', '~> 4.7', '>= 4.7.1'
 
 # Start debugger with binding.b [https://github.com/ruby/debug]
 # gem "debug", ">= 1.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,6 +143,7 @@ GEM
       thor (~> 1.0)
       zeitwerk (~> 2.5)
     rake (13.0.6)
+    redis (4.7.1)
     sprockets (4.0.3)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -167,6 +168,7 @@ PLATFORMS
 DEPENDENCIES
   importmap-rails (~> 1.1, >= 1.1.2)
   puma (~> 5.6, >= 5.6.4)
+  redis (~> 4.7, >= 4.7.1)
   sprockets-rails
   sqlite3
   turbo_clone!

--- a/app/channels/turbo_clone/streams/broadcasts.rb
+++ b/app/channels/turbo_clone/streams/broadcasts.rb
@@ -5,6 +5,10 @@ module TurboClone::Streams::Broadcasts
     broadcast_action_to(*streamables, action: :append, **options)
   end
 
+  def broadcast_prepend_to(*streamables, **options)
+    broadcast_action_to(*streamables, action: :prepend, **options)
+  end
+
   def broadcast_action_to(*streamables, action:, target: nil, **rendering)
     broadcast_stream_to *streamables, content: turbo_stream_action_tag(
       action, target: target, template: (rendering.any? ? render_format(:html, **rendering) : nil)

--- a/app/channels/turbo_clone/streams/broadcasts.rb
+++ b/app/channels/turbo_clone/streams/broadcasts.rb
@@ -1,0 +1,23 @@
+module TurboClone::Streams::Broadcasts
+  include TurboClone::ActionHelper
+
+  def broadcast_append_to(*streamables, **options)
+    broadcast_action_to(*streamables, action: :append, **options)
+  end
+
+  def broadcast_action_to(*streamables, action:, target: nil, **rendering)
+    broadcast_stream_to *streamables, content: turbo_stream_action_tag(
+      action, target: target, template: (rendering.any? ? render_format(:html, **rendering) : nil)
+    )
+  end
+
+  def broadcast_stream_to(*streamables, content:)
+    ActionCable.server.broadcast stream_name_from(streamables), content    
+  end
+
+  private
+
+  def render_format(format, **rendering)
+    ApplicationController.render(formats: [format], **rendering)    
+  end
+end

--- a/app/channels/turbo_clone/streams/broadcasts.rb
+++ b/app/channels/turbo_clone/streams/broadcasts.rb
@@ -11,6 +11,10 @@ module TurboClone::Streams::Broadcasts
 
   def broadcast_replace_to(*streamables, **options)
     broadcast_action_to(*streamables, action: :replace, **options)
+  end
+
+  def broadcast_remove_to(*streamables, **options)
+    broadcast_action_to(*streamables, action: :remove, **options)
   end  
 
   def broadcast_action_to(*streamables, action:, target: nil, **rendering)

--- a/app/channels/turbo_clone/streams/broadcasts.rb
+++ b/app/channels/turbo_clone/streams/broadcasts.rb
@@ -9,6 +9,10 @@ module TurboClone::Streams::Broadcasts
     broadcast_action_to(*streamables, action: :prepend, **options)
   end
 
+  def broadcast_replace_to(*streamables, **options)
+    broadcast_action_to(*streamables, action: :replace, **options)
+  end  
+
   def broadcast_action_to(*streamables, action:, target: nil, **rendering)
     broadcast_stream_to *streamables, content: turbo_stream_action_tag(
       action, target: target, template: (rendering.any? ? render_format(:html, **rendering) : nil)

--- a/app/channels/turbo_clone/streams/stream_name.rb
+++ b/app/channels/turbo_clone/streams/stream_name.rb
@@ -1,0 +1,13 @@
+module TurboClone::Streams::StreamName
+    
+  def stream_name_from(streamables)
+    if streamables.is_a?(Array)
+      streamables.map { |streamable| stream_name_from(streamable) }.join(":")
+    else
+      streamables.then do |streamable|
+        streamable.respond_to?(:to_key) ? ActionView::RecordIdentifier.dom_id(streamable) : streamable
+      end
+    end
+  end
+  
+end

--- a/app/channels/turbo_clone/streams_channel.rb
+++ b/app/channels/turbo_clone/streams_channel.rb
@@ -1,5 +1,5 @@
 class TurboClone::StreamsChannel < ActionCable::Channel::Base
-  extend TurboClone::Streams::StreamName
+  extend TurboClone::Streams::StreamName, TurboClone::Streams::Broadcasts
 
   def subscribed
     stream_from params[:signed_stream_name]

--- a/app/channels/turbo_clone/streams_channel.rb
+++ b/app/channels/turbo_clone/streams_channel.rb
@@ -1,0 +1,7 @@
+class TurboClone::StreamsChannel < ActionCable::Channel::Base
+  extend TurboClone::Streams::StreamName
+
+  def subscribed
+    stream_from params[:signed_stream_name]
+  end
+end

--- a/app/helpers/turbo_clone/action_helper.rb
+++ b/app/helpers/turbo_clone/action_helper.rb
@@ -1,0 +1,19 @@
+module TurboClone::ActionHelper
+  def turbo_stream_action_tag(action, target:, template:)
+    template = action == :remove ? "" : "<template>#{template}</template>"
+
+    if target = convert_to_turbo_stream_dom_id(target)
+      %(<turbo-stream target="#{target}" action="#{action}">#{template}</turbo-stream>).html_safe
+    else
+      raise ArgumentError, "Target must be supplied"
+    end
+  end
+
+  def convert_to_turbo_stream_dom_id(target)
+    if target.respond_to?(:to_key)
+      ActionView::RecordIdentifier.dom_id(target)
+    else
+      target
+    end
+  end
+end

--- a/app/helpers/turbo_clone/streams_helper.rb
+++ b/app/helpers/turbo_clone/streams_helper.rb
@@ -2,4 +2,11 @@ module TurboClone::StreamsHelper
   def turbo_stream
     TurboClone::Streams::TagBuilder.new(self)
   end
+
+  def turbo_stream_from(*streamables, **attributes)
+    attributes[:channel] = "TurboClone::StreamsChannel"
+    attributes[:"signed-stream-name"] = TurboClone::StreamsChannel.stream_name_from(streamables)
+
+    tag.turbo_cable_stream_source(**attributes)
+  end
 end

--- a/app/models/concerns/turbo_clone/broadcastable.rb
+++ b/app/models/concerns/turbo_clone/broadcastable.rb
@@ -1,0 +1,26 @@
+module TurboClone::Broadcastable
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def broadcast_target_default
+     model_name.plural 
+    end
+  end
+  
+  def broadcast_append_to(*streamables, target: broadcast_target_default, **rendering)
+    TurboClone::StreamsChannel.broadcast_append_to(*streamables, target: target, **broadcast_rendering_with_defaults(rendering))
+  end
+
+  private
+
+  def broadcast_rendering_with_defaults(rendering)
+    rendering.tap do |r|
+      r[:locals] = (r[:locals] || {}).reverse_merge!(model_name.element.to_sym => self)
+      r[:partial] ||= to_partial_path
+    end
+  end
+
+  def broadcast_target_default
+    self.class.broadcast_target_default
+  end
+end

--- a/app/models/concerns/turbo_clone/broadcastable.rb
+++ b/app/models/concerns/turbo_clone/broadcastable.rb
@@ -15,6 +15,10 @@ module TurboClone::Broadcastable
     TurboClone::StreamsChannel.broadcast_prepend_to(*streamables, target: target, **broadcast_rendering_with_defaults(rendering))
   end
 
+  def broadcast_replace_to(*streamables, target: self, **rendering)
+    TurboClone::StreamsChannel.broadcast_replace_to(*streamables, target: target, **broadcast_rendering_with_defaults(rendering))
+  end
+  
   private
 
   def broadcast_rendering_with_defaults(rendering)

--- a/app/models/concerns/turbo_clone/broadcastable.rb
+++ b/app/models/concerns/turbo_clone/broadcastable.rb
@@ -3,7 +3,7 @@ module TurboClone::Broadcastable
 
   class_methods do
     def broadcast_target_default
-     model_name.plural 
+      model_name.plural 
     end
   end
   
@@ -18,6 +18,10 @@ module TurboClone::Broadcastable
   def broadcast_replace_to(*streamables, target: self, **rendering)
     TurboClone::StreamsChannel.broadcast_replace_to(*streamables, target: target, **broadcast_rendering_with_defaults(rendering))
   end
+
+  def broadcast_remove_to(*streamables, target: self)
+    TurboClone::StreamsChannel.broadcast_remove_to(*streamables, target: target)
+  end  
   
   private
 

--- a/app/models/concerns/turbo_clone/broadcastable.rb
+++ b/app/models/concerns/turbo_clone/broadcastable.rb
@@ -11,6 +11,10 @@ module TurboClone::Broadcastable
     TurboClone::StreamsChannel.broadcast_append_to(*streamables, target: target, **broadcast_rendering_with_defaults(rendering))
   end
 
+  def broadcast_prepend_to(*streamables, target: broadcast_target_default, **rendering)
+    TurboClone::StreamsChannel.broadcast_prepend_to(*streamables, target: target, **broadcast_rendering_with_defaults(rendering))
+  end
+
   private
 
   def broadcast_rendering_with_defaults(rendering)

--- a/app/models/turbo_clone/streams/tag_builder.rb
+++ b/app/models/turbo_clone/streams/tag_builder.rb
@@ -1,4 +1,6 @@
 class TurboClone::Streams::TagBuilder
+  include TurboClone::ActionHelper
+
   def initialize(view_context)
     @view_context = view_context
     @view_context.formats |= [:html]
@@ -26,24 +28,6 @@ class TurboClone::Streams::TagBuilder
     template = render_template(target, content, **rendering, &block) unless name == :remove
 
     turbo_stream_action_tag(name, target: target, template: template)
-  end
-
-  def turbo_stream_action_tag(action, target:, template:)
-    template = action == :remove ? "" : "<template>#{template}</template>"
-
-    if target = convert_to_turbo_stream_dom_id(target)
-      %(<turbo-stream target="#{target}" action="#{action}">#{template}</turbo-stream>).html_safe
-    else
-      raise ArgumentError, "Target must be supplied"
-    end
-  end
-
-  def convert_to_turbo_stream_dom_id(target)
-    if target.respond_to?(:to_key)
-      ActionView::RecordIdentifier.dom_id(target)
-    else
-      target
-    end
   end
 
   def render_template(target, content = nil, **rendering, &block)

--- a/lib/turbo_clone/engine.rb
+++ b/lib/turbo_clone/engine.rb
@@ -15,6 +15,12 @@ module TurboClone
       end
     end
 
+    initializer "turbo.broadcastable" do
+      ActiveSupport.on_load :active_record do
+        include TurboClone::Broadcastable
+      end
+    end
+
     initializer "turbo.renderer" do
       ActiveSupport.on_load :action_controller do
         ActionController::Renderers.add :turbo_stream do |turbo_stream_html, options|

--- a/test/channels/broadcastable_test.rb
+++ b/test/channels/broadcastable_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class TurboClone::BroadcastableTest < ActionCable::Channel::TestCase
+  include TurboClone::ActionHelper
+
+  test "#broadcast_append_to" do
+    article = Article.create! content: "content"
+
+    assert_broadcast_on "stream", turbo_stream_action_tag(:append, target: "articles", template: render(article)) do
+      article.broadcast_append_to "stream"      
+    end
+  end
+end

--- a/test/channels/broadcastable_test.rb
+++ b/test/channels/broadcastable_test.rb
@@ -25,5 +25,13 @@ class TurboClone::BroadcastableTest < ActionCable::Channel::TestCase
     assert_broadcast_on "stream", turbo_stream_action_tag(:replace, target: article, template: render(article)) do
       article.broadcast_replace_to "stream"
     end
+  end
+
+test "#broadcast_remove_to" do
+    article = Article.create! content: "content"
+
+    assert_broadcast_on "stream", turbo_stream_action_tag(:remove, target: article, template: nil) do
+      article.broadcast_remove_to "stream"
+    end
   end  
 end

--- a/test/channels/broadcastable_test.rb
+++ b/test/channels/broadcastable_test.rb
@@ -18,4 +18,12 @@ class TurboClone::BroadcastableTest < ActionCable::Channel::TestCase
       article.broadcast_prepend_to "stream", target: "prepended article"
     end
   end
+
+  test "#broadcast_replace_to" do
+    article = Article.create! content: "content"
+
+    assert_broadcast_on "stream", turbo_stream_action_tag(:replace, target: article, template: render(article)) do
+      article.broadcast_replace_to "stream"
+    end
+  end  
 end

--- a/test/channels/broadcastable_test.rb
+++ b/test/channels/broadcastable_test.rb
@@ -10,4 +10,12 @@ class TurboClone::BroadcastableTest < ActionCable::Channel::TestCase
       article.broadcast_append_to "stream"      
     end
   end
+
+  test "#broadcast_prepend_to" do
+    article = Article.create! content: "content"
+
+    assert_broadcast_on "stream", turbo_stream_action_tag(:prepend, target: "prepended article", template: render(article)) do
+      article.broadcast_prepend_to "stream", target: "prepended article"
+    end
+  end
 end

--- a/test/dummy/app/models/article.rb
+++ b/test/dummy/app/models/article.rb
@@ -1,3 +1,5 @@
 class Article < ApplicationRecord
   validates :content, presence: true
+
+  after_create_commit { broadcast_append_to "articles" }
 end

--- a/test/dummy/app/models/article.rb
+++ b/test/dummy/app/models/article.rb
@@ -2,5 +2,6 @@ class Article < ApplicationRecord
   validates :content, presence: true
 
   after_create_commit { broadcast_prepend_to "articles" }
+  after_update_commit { broadcast_replace_to "articles" }
 
 end

--- a/test/dummy/app/models/article.rb
+++ b/test/dummy/app/models/article.rb
@@ -1,5 +1,6 @@
 class Article < ApplicationRecord
   validates :content, presence: true
 
-  after_create_commit { broadcast_append_to "articles" }
+  after_create_commit { broadcast_prepend_to "articles" }
+
 end

--- a/test/dummy/app/models/article.rb
+++ b/test/dummy/app/models/article.rb
@@ -3,5 +3,5 @@ class Article < ApplicationRecord
 
   after_create_commit { broadcast_prepend_to "articles" }
   after_update_commit { broadcast_replace_to "articles" }
-
+  after_destroy_commit { broadcast_remove_to "articles" }
 end

--- a/test/dummy/app/views/articles/index.html.erb
+++ b/test/dummy/app/views/articles/index.html.erb
@@ -1,3 +1,5 @@
+<%= turbo_stream_from "articles" %>
+
 <h1>Articles</h1>
 
 <%= link_to "New article",

--- a/test/dummy/config/cable.yml
+++ b/test/dummy/config/cable.yml
@@ -1,5 +1,6 @@
 development:
-  adapter: async
+  adapter: redis
+  url: redis://localhost:6379/0
 
 test:
   adapter: test

--- a/test/helpers/streams_helper_test.rb
+++ b/test/helpers/streams_helper_test.rb
@@ -1,0 +1,25 @@
+require "test_helper"
+
+class TurboClone::StreamsHelperTest < ActionView::TestCase
+  test "with a string streamable" do
+    assert_dom_equal \
+      %(<turbo-cable-stream-source channel="TurboClone::StreamsChannel" signed-stream-name="articles"></turbo-cable-stream-source>),
+    turbo_stream_from("articles")
+  end
+
+  test "with a model streamable" do
+    article = Article.new(id: 1)
+
+    assert_dom_equal \
+      %(<turbo-cable-stream-source channel="TurboClone::StreamsChannel" signed-stream-name="article_1"></turbo-cable-stream-source>),
+    turbo_stream_from(article)
+  end
+
+  test "with multiple streamables" do
+    article = Article.new(id: 1)
+
+    assert_dom_equal \
+      %(<turbo-cable-stream-source channel="TurboClone::StreamsChannel" signed-stream-name="articles:article_1"></turbo-cable-stream-source>),
+    turbo_stream_from("articles", article)
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,3 +23,7 @@ end
 class ActionDispatch::IntegrationTest
   include ActionViewTestCaseExtensions
 end
+
+class ActionCable::Channel::TestCase
+  include ActionViewTestCaseExtensions
+end


### PR DESCRIPTION
This PR integrates ActionCable into Turbo Streams, to allow the creation, editing, and deletion of DOM elements via websockets.