### PR TITLE
ActiveJob async broadcasts

### DIFF
--- a/app/channels/turbo_clone/streams/broadcasts.rb
+++ b/app/channels/turbo_clone/streams/broadcasts.rb
@@ -37,6 +37,10 @@ module TurboClone::Streams::Broadcasts
     broadcast_action_later_to(*streamables, action: :prepend, **options)
   end
 
+  def broadcast_replace_later_to(*streamables, **options)
+    broadcast_action_later_to(*streamables, action: :replace, **options)
+  end
+
   def broadcast_stream_to(*streamables, content:)
     ActionCable.server.broadcast stream_name_from(streamables), content    
   end

--- a/app/channels/turbo_clone/streams/broadcasts.rb
+++ b/app/channels/turbo_clone/streams/broadcasts.rb
@@ -33,6 +33,10 @@ module TurboClone::Streams::Broadcasts
     broadcast_action_later_to(*streamables, action: :append, **options)
   end
 
+  def broadcast_prepend_later_to(*streamables, **options)
+    broadcast_action_later_to(*streamables, action: :prepend, **options)
+  end
+
   def broadcast_stream_to(*streamables, content:)
     ActionCable.server.broadcast stream_name_from(streamables), content    
   end

--- a/app/channels/turbo_clone/streams/broadcasts.rb
+++ b/app/channels/turbo_clone/streams/broadcasts.rb
@@ -23,6 +23,16 @@ module TurboClone::Streams::Broadcasts
     )
   end
 
+  def broadcast_action_later_to(*streamables, action:, target: nil, **rendering)
+    TurboClone::Streams::ActionBroadcastJob.perform_later(
+      stream_name_from(streamables), action: action, target: target, **rendering
+    )
+  end
+
+  def broadcast_append_later_to(*streamables, **options)
+    broadcast_action_later_to(*streamables, action: :append, **options)
+  end
+
   def broadcast_stream_to(*streamables, content:)
     ActionCable.server.broadcast stream_name_from(streamables), content    
   end

--- a/app/jobs/turbo_clone/streams/action_broadcast_job.rb
+++ b/app/jobs/turbo_clone/streams/action_broadcast_job.rb
@@ -1,0 +1,7 @@
+class TurboClone::Streams::ActionBroadcastJob < ActiveJob::Base
+  discard_on ActiveJob::DeserializationError
+
+  def perform(stream, action:, target:, **rendering)
+    TurboClone::StreamsChannel.broadcast_action_to(stream, action: action, target: target, **rendering)
+  end
+end

--- a/app/models/concerns/turbo_clone/broadcastable.rb
+++ b/app/models/concerns/turbo_clone/broadcastable.rb
@@ -21,6 +21,10 @@ module TurboClone::Broadcastable
 
   def broadcast_remove_to(*streamables, target: self)
     TurboClone::StreamsChannel.broadcast_remove_to(*streamables, target: target)
+  end
+
+  def broadcast_append_later_to(*streamables, target: broadcast_target_default, **rendering)
+    TurboClone::StreamsChannel.broadcast_append_later_to(*streamables, target: target, **broadcast_rendering_with_defaults(rendering))
   end  
   
   private

--- a/app/models/concerns/turbo_clone/broadcastable.rb
+++ b/app/models/concerns/turbo_clone/broadcastable.rb
@@ -29,7 +29,11 @@ module TurboClone::Broadcastable
 
   def broadcast_prepend_later_to(*streamables, target: broadcast_target_default, **rendering)
     TurboClone::StreamsChannel.broadcast_prepend_later_to(*streamables, target: target, **broadcast_rendering_with_defaults(rendering))
-  end    
+  end
+
+  def broadcast_replace_later_to(*streamables, target: self, **rendering)
+    TurboClone::StreamsChannel.broadcast_replace_later_to(*streamables, target: target, **broadcast_rendering_with_defaults(rendering))
+  end
   
   private
 

--- a/app/models/concerns/turbo_clone/broadcastable.rb
+++ b/app/models/concerns/turbo_clone/broadcastable.rb
@@ -25,7 +25,11 @@ module TurboClone::Broadcastable
 
   def broadcast_append_later_to(*streamables, target: broadcast_target_default, **rendering)
     TurboClone::StreamsChannel.broadcast_append_later_to(*streamables, target: target, **broadcast_rendering_with_defaults(rendering))
-  end  
+  end
+
+  def broadcast_prepend_later_to(*streamables, target: broadcast_target_default, **rendering)
+    TurboClone::StreamsChannel.broadcast_prepend_later_to(*streamables, target: target, **broadcast_rendering_with_defaults(rendering))
+  end    
   
   private
 

--- a/test/channels/broadcastable_test.rb
+++ b/test/channels/broadcastable_test.rb
@@ -2,12 +2,23 @@ require "test_helper"
 
 class TurboClone::BroadcastableTest < ActionCable::Channel::TestCase
   include TurboClone::ActionHelper
+  include ActiveJob::TestHelper
 
   test "#broadcast_append_to" do
     article = Article.create! content: "content"
 
     assert_broadcast_on "stream", turbo_stream_action_tag(:append, target: "articles", template: render(article)) do
       article.broadcast_append_to "stream"      
+    end
+  end
+
+  test "#broadcast_append_later_to" do
+    article = Article.create! content: "content"
+
+    assert_broadcast_on "stream", turbo_stream_action_tag(:append, target: "articles", template: render(article)) do
+      perform_enqueued_jobs do
+        article.broadcast_append_later_to "stream"        
+      end
     end
   end
 
@@ -19,11 +30,31 @@ class TurboClone::BroadcastableTest < ActionCable::Channel::TestCase
     end
   end
 
+  test "#broadcast_prepend_later_to" do
+    article = Article.create! content: "content"
+
+    assert_broadcast_on "stream", turbo_stream_action_tag(:prepend, target: "prepended article", template: render(article)) do
+      perform_enqueued_jobs do
+        article.broadcast_prepend_later_to "stream", target: "prepended article"        
+      end
+    end
+  end
+
   test "#broadcast_replace_to" do
     article = Article.create! content: "content"
 
     assert_broadcast_on "stream", turbo_stream_action_tag(:replace, target: article, template: render(article)) do
       article.broadcast_replace_to "stream"
+    end
+  end
+
+  test "#broadcast_replace_later_to" do
+    article = Article.create! content: "content"
+
+    assert_broadcast_on "stream", turbo_stream_action_tag(:replace, target: article, template: render(article)) do
+      perform_enqueued_jobs do
+        article.broadcast_replace_later_to "stream"
+      end
     end
   end
 

--- a/test/dummy/app/models/article.rb
+++ b/test/dummy/app/models/article.rb
@@ -1,7 +1,7 @@
 class Article < ApplicationRecord
   validates :content, presence: true
 
-  after_create_commit { broadcast_prepend_to "articles" }
+  after_create_commit { broadcast_append_later_to "articles" }
   after_update_commit { broadcast_replace_to "articles" }
   after_destroy_commit { broadcast_remove_to "articles" }
 end

--- a/test/dummy/app/models/article.rb
+++ b/test/dummy/app/models/article.rb
@@ -1,7 +1,7 @@
 class Article < ApplicationRecord
   validates :content, presence: true
 
-  after_create_commit { broadcast_append_later_to "articles" }
+  after_create_commit { broadcast_prepend_later_to "articles" }
   after_update_commit { broadcast_replace_to "articles" }
   after_destroy_commit { broadcast_remove_to "articles" }
 end

--- a/test/dummy/app/models/article.rb
+++ b/test/dummy/app/models/article.rb
@@ -2,6 +2,6 @@ class Article < ApplicationRecord
   validates :content, presence: true
 
   after_create_commit { broadcast_prepend_later_to "articles" }
-  after_update_commit { broadcast_replace_to "articles" }
+  after_update_commit { broadcast_replace_later_to "articles" }
   after_destroy_commit { broadcast_remove_to "articles" }
 end


### PR DESCRIPTION
Set up ActiveJob asynchronous broadcasts, so broadcasts can update later, based on queue.

Implemented the following async features:
- append new articles
- prepend new articles
- update articles