### PR TITLE
Implement securely-signed streams for Turbo Stream broadcasts

### DIFF
--- a/app/channels/turbo_clone/streams/stream_name.rb
+++ b/app/channels/turbo_clone/streams/stream_name.rb
@@ -1,5 +1,12 @@
 module TurboClone::Streams::StreamName
-    
+  def verified_stream_name(signed_stream_name)
+    TurboClone.signed_stream_verifier.verified signed_stream_name
+  end
+
+  def signed_stream_name(streamables)
+    TurboClone.signed_stream_verifier.generate stream_name_from(streamables)
+  end
+
   def stream_name_from(streamables)
     if streamables.is_a?(Array)
       streamables.map { |streamable| stream_name_from(streamable) }.join(":")
@@ -9,5 +16,4 @@ module TurboClone::Streams::StreamName
       end
     end
   end
-  
 end

--- a/app/channels/turbo_clone/streams_channel.rb
+++ b/app/channels/turbo_clone/streams_channel.rb
@@ -2,6 +2,10 @@ class TurboClone::StreamsChannel < ActionCable::Channel::Base
   extend TurboClone::Streams::StreamName, TurboClone::Streams::Broadcasts
 
   def subscribed
-    stream_from params[:signed_stream_name]
+    if verified_stream_name = self.class.verified_stream_name(params[:signed_stream_name])
+      stream_from verified_stream_name
+    else
+      reject
+    end
   end
 end

--- a/app/helpers/turbo_clone/streams_helper.rb
+++ b/app/helpers/turbo_clone/streams_helper.rb
@@ -5,7 +5,7 @@ module TurboClone::StreamsHelper
 
   def turbo_stream_from(*streamables, **attributes)
     attributes[:channel] = "TurboClone::StreamsChannel"
-    attributes[:"signed-stream-name"] = TurboClone::StreamsChannel.stream_name_from(streamables)
+    attributes[:"signed-stream-name"] = TurboClone::StreamsChannel.signed_stream_name(streamables)
 
     tag.turbo_cable_stream_source(**attributes)
   end

--- a/lib/turbo_clone.rb
+++ b/lib/turbo_clone.rb
@@ -2,5 +2,16 @@ require "turbo_clone/version"
 require "turbo_clone/engine"
 
 module TurboClone
-  # Your code goes here...
+  class << self
+    attr_writer :signed_stream_verifier_key
+
+    def signed_stream_verifier
+      @signed_stream_verifier ||=
+        ActiveSupport::MessageVerifier.new(signed_stream_verifier_key, digest: "SHA256", serializer: JSON)
+    end
+
+    def signed_stream_verifier_key
+      @signed_stream_verifier_key or raise ArgumentError, "Turbo requires a signed_stream_verifier_key."
+    end
+  end
 end

--- a/lib/turbo_clone/engine.rb
+++ b/lib/turbo_clone/engine.rb
@@ -4,6 +4,13 @@ module TurboClone
   class Engine < ::Rails::Engine
     isolate_namespace TurboClone
 
+    config.turbo = ActiveSupport::OrderedOptions.new
+
+    initializer "turbo.signed_stream_verifier_key" do
+      TurboClone.signed_stream_verifier_key = config.turbo.signed_stream_verifier_key ||
+                                              Rails.application.key_generator.generate_key("turbo/signed_stream_verifier_key")
+    end
+
     initializer "turbo.media_type" do
       Mime::Type.register "text/vnd.turbo-stream.html", :turbo_stream
     end
@@ -14,7 +21,7 @@ module TurboClone
         helper TurboClone::Engine.helpers              
       end
     end
-
+    
     initializer "turbo.broadcastable" do
       ActiveSupport.on_load :active_record do
         include TurboClone::Broadcastable

--- a/test/helpers/streams_helper_test.rb
+++ b/test/helpers/streams_helper_test.rb
@@ -2,24 +2,28 @@ require "test_helper"
 
 class TurboClone::StreamsHelperTest < ActionView::TestCase
   test "with a string streamable" do
+    signed_stream_name = TurboClone::StreamsChannel.signed_stream_name("articles")
+
     assert_dom_equal \
-      %(<turbo-cable-stream-source channel="TurboClone::StreamsChannel" signed-stream-name="articles"></turbo-cable-stream-source>),
+      %(<turbo-cable-stream-source channel="TurboClone::StreamsChannel" signed-stream-name="#{signed_stream_name}"></turbo-cable-stream-source>),
     turbo_stream_from("articles")
   end
 
   test "with a model streamable" do
     article = Article.new(id: 1)
+    signed_stream_name = TurboClone::StreamsChannel.signed_stream_name(article)
 
     assert_dom_equal \
-      %(<turbo-cable-stream-source channel="TurboClone::StreamsChannel" signed-stream-name="article_1"></turbo-cable-stream-source>),
+      %(<turbo-cable-stream-source channel="TurboClone::StreamsChannel" signed-stream-name="#{signed_stream_name}"></turbo-cable-stream-source>),
     turbo_stream_from(article)
   end
 
   test "with multiple streamables" do
     article = Article.new(id: 1)
+    signed_stream_name = TurboClone::StreamsChannel.signed_stream_name(["articles", article])
 
     assert_dom_equal \
-      %(<turbo-cable-stream-source channel="TurboClone::StreamsChannel" signed-stream-name="articles:article_1"></turbo-cable-stream-source>),
+      %(<turbo-cable-stream-source channel="TurboClone::StreamsChannel" signed-stream-name="#{signed_stream_name}"></turbo-cable-stream-source>),
     turbo_stream_from("articles", article)
   end
 end


### PR DESCRIPTION
This PR implements signed stream names. With plain-text stream names, an attacker could hijack a Turbo stream and change the name. 

This update introduces a signed stream name that prevents attackers from tampering with a stream by generating a key with SHA-256 encryption, which is checked for authenticity by the server. If the signature is tampered with, access is denied.

