### PR TITLE
Set up rake turbo:install task

### DIFF
--- a/lib/install/turbo_needs_redis.rb
+++ b/lib/install/turbo_needs_redis.rb
@@ -1,0 +1,20 @@
+if (cable_config_path = Rails.root.join("config/cable.yml")).exist?
+  say "Enable Redis in Gemfile"
+  gemfile_content = File.read(Rails.root.join("Gemfile"))
+  pattern = /gem ["']redis['"]/
+
+  if gemfile_content.match?(pattern)
+    uncomment_lines "Gemfile", pattern
+  else
+    append_file "Gemfile", "\n# Use Redis for ActionCable"
+    gem 'redis', '~> 4.7.1'
+  end
+
+  run_bundle
+
+  say "Switch development cable to Redis in config/cable.yml"
+
+  gsub_file cable_config_path, /development:\n\s+adapter: async/, "development:\n adapter: redis\n url: redis://localhost:6379/1"
+else
+  say "Turbo requires ActionCable to work."
+end

--- a/lib/install/turbo_with_importmap.rb
+++ b/lib/install/turbo_with_importmap.rb
@@ -1,0 +1,5 @@
+say "Import Turbo"
+append_to_file "app/javascript/application.js", %(import "@hotwired/turbo-rails")
+
+say "Pin Turbo"
+run "importmap pin @hotwired/turbo-rails@7.1.1"

--- a/lib/tasks/turbo_clone_tasks.rake
+++ b/lib/tasks/turbo_clone_tasks.rake
@@ -1,4 +1,34 @@
-# desc "Explaining what the task does"
-# task :turbo_clone do
-#   # Task goes here
-# end
+def run_turbo_install_template(path)
+  system "bin/rails app:template LOCATION="#{File.expand_path("../install/#{path}.rb", __dir__)}
+end
+
+def redis_installed?
+  if Gem.win_platform?
+    system "where redis-server > NUL 2>&1"
+  else
+    system "which redis-server > /dev/null"
+  end
+end
+
+def switch_on_redis_if_available
+  if redis_installed?
+    Rake::Task[:turbo_clone:install:redis].invoke
+  else
+    puts "Run turbo_clone:install:redis to swtich on Redis and use it in development"
+  end
+end
+
+namespace :turbo_clone do
+  desc "Install Turbo into the application"
+  task :install do
+    run_turbo_install_template "turbo_with_importmap"
+    switch_on_redis_if_available
+  end
+
+  namespace :install do
+    desc "Switch on Redis and use it in development"
+    task :redis do
+      run_turbo_install_template "turbo_needs_redis"
+    end
+  end
+end

--- a/test/dummy/config/cable.yml
+++ b/test/dummy/config/cable.yml
@@ -1,6 +1,6 @@
 development:
   adapter: redis
-  url: redis://localhost:6379/0
+  url: redis://localhost:6379/1
 
 test:
   adapter: test


### PR DESCRIPTION
This PR sets up a rake task to install the Turbo Rails Clone engine:
- It checks the system to ensure that Redis is installed. If not, it prompts the user to install it.
- It automates the installation:
  - ensures that the Redis gem is uncommented and installed via the Gemfile, or installs it directly
  - pins the necessary JS dependencies to the importmap