### PR TITLE
Fix typo in `lib/tasks/turbo_clone_tasks.rake` file

### DIFF
--- a/lib/tasks/turbo_clone_tasks.rake
+++ b/lib/tasks/turbo_clone_tasks.rake
@@ -12,7 +12,7 @@ end
 
 def switch_on_redis_if_available
   if redis_installed?
-    Rake::Task[:turbo_clone:install:redis].invoke
+    Rake::Task["turbo_clone:install:redis"].invoke
   else
     puts "Run turbo_clone:install:redis to swtich on Redis and use it in development"
   end


### PR DESCRIPTION
This PR fixes a minor typo on line 15 that prevents the installation process from succeeding in a new Rails installation.

- error: `Rake::Task[:turbo_clone:install:redis].invoke`
- correction: `Rake::Task["turbo_clone:install:redis"].invoke`